### PR TITLE
Check mod registration on each gamescene

### DIFF
--- a/RecoveryController/RecoveryController.cs
+++ b/RecoveryController/RecoveryController.cs
@@ -273,7 +273,7 @@ namespace RecoveryController
     /// <summary>
     /// Class to take care of things in the editor
     /// </summary>
-    [KSPAddon(KSPAddon.Startup.SpaceCentre, false)]
+    [KSPAddon(KSPAddon.Startup.AllGameScenes, false)]
     public class RecoveryController : MonoBehaviour
     {
         const string AUTO = "auto";


### PR DESCRIPTION
Fix issue reported in the forum: 
https://forum.kerbalspaceprogram.com/index.php?/topic/157214-151-flight-manager-for-reusable-stages-fmrs-now-with-recoverycontroller-integration/&do=findComment&comment=3507243

Maybe requires a recompile of StageRecovery as well. At least for me, it wasn't working properly even with this change. The 'fake mods' "auto" and "none" still didn't appear when cycling through the Recovery Owner. after recompiling StageRecovery (wihtout any changes to the code) as well, everything works as intended.