### PR TITLE
Added support for Universal Storage Decouplers

### DIFF
--- a/GameData/RecoveryController/RecoveryController_MM.cfg
+++ b/GameData/RecoveryController/RecoveryController_MM.cfg
@@ -5,7 +5,14 @@
 		name = RecoveryIDModule
 	}
 }
-@PART[*]:HAS[!MODULE[ModuleAnchoredDecoupler],!MODULE[ModuleDecouple]]:NEEDS[StageRecovery]
+@PART[*]:HAS[@MODULE[USDecouple]]:NEEDS[StageRecovery]
+{
+	MODULE
+	{
+		name = RecoveryIDModule
+	}
+}
+@PART[*]:HAS[!MODULE[ModuleAnchoredDecoupler],!MODULE[ModuleDecouple],!MODULE[USDecouple]]:NEEDS[StageRecovery]
 {
 	MODULE
 	{


### PR DESCRIPTION
The decouplers in the Universal Storage Mod apparently don't follow the regular naming scheme for decoupler modules, this resulted in FMRS not seeing the decoupled stages. This PR fixes that.